### PR TITLE
add valid sample and fixes

### DIFF
--- a/cert-wallet.xcodeproj/project.pbxproj
+++ b/cert-wallet.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3BDF6E961D73F40C00EC005C /* CertificateValidationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8369CB101D70B805006D603E /* CertificateValidationRequest.swift */; };
 		3BDF6E981D73F52100EC005C /* TransactionDataHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDF6E971D73F52100EC005C /* TransactionDataHandler.swift */; };
 		3BDF6E991D73FFFA00EC005C /* TransactionDataHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDF6E971D73F52100EC005C /* TransactionDataHandler.swift */; };
+		3BDF6E9F1D74C2D900EC005C /* sample_signed_cert-valid-1.1.0.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BDF6E9D1D74C2D900EC005C /* sample_signed_cert-valid-1.1.0.json */; };
 		3BF0FCEC1D64DA6100CCEC57 /* Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF0FCEB1D64DA6100CCEC57 /* Validate.swift */; };
 		3BF0FCF01D66240F00CCEC57 /* sample_signed_cert-1.1.0.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BF0FCEF1D66240F00CCEC57 /* sample_signed_cert-1.1.0.json */; };
 		53D1A4D647C466C91012AF06 /* libPods-cert-walletUITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 63DAA36016F0A82280FC66C2 /* libPods-cert-walletUITests.a */; };
@@ -103,6 +104,7 @@
 		2480E99759E82A39B681E528 /* libPods-cert-walletTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-cert-walletTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2EC550FD5CE48EBC6F6DB6F5 /* Pods-cert-walletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-cert-walletTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-cert-walletTests/Pods-cert-walletTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3BDF6E971D73F52100EC005C /* TransactionDataHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDataHandler.swift; sourceTree = "<group>"; };
+		3BDF6E9D1D74C2D900EC005C /* sample_signed_cert-valid-1.1.0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "sample_signed_cert-valid-1.1.0.json"; path = "../../../cert-verifier/sample_data/1.1.0/sample_signed_cert-valid-1.1.0.json"; sourceTree = "<group>"; };
 		3BF0FCEB1D64DA6100CCEC57 /* Validate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Validate.swift; path = Models/Validate.swift; sourceTree = "<group>"; };
 		3BF0FCEF1D66240F00CCEC57 /* sample_signed_cert-1.1.0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "sample_signed_cert-1.1.0.json"; sourceTree = "<group>"; };
 		4577D4DA579179516CE8C7E7 /* Pods-cert-wallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-cert-wallet.release.xcconfig"; path = "Pods/Target Support Files/Pods-cert-wallet/Pods-cert-wallet.release.xcconfig"; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 		834F2EE71D624FCF008C9650 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				3BDF6E9D1D74C2D900EC005C /* sample_signed_cert-valid-1.1.0.json */,
 				835B62451D63B1E500C95EB8 /* sample_signed_cert-1.2.0.json */,
 				3BF0FCEF1D66240F00CCEC57 /* sample_signed_cert-1.1.0.json */,
 				834F2EE81D624FCF008C9650 /* sample_unsigned_cert-1.1.0.json */,
@@ -468,6 +471,7 @@
 			files = (
 				3BF0FCF01D66240F00CCEC57 /* sample_signed_cert-1.1.0.json in Resources */,
 				835B62461D63B1E500C95EB8 /* sample_signed_cert-1.2.0.json in Resources */,
+				3BDF6E9F1D74C2D900EC005C /* sample_signed_cert-valid-1.1.0.json in Resources */,
 				834F2EEB1D624FCF008C9650 /* sample_unsigned_cert-invalid_no_email-1.2.0.json in Resources */,
 				835B624E1D64BDB700C95EB8 /* sample_unsigned_cert-1.2.0.json in Resources */,
 				834F2EEA1D624FCF008C9650 /* sample_unsigned_cert-1.1.0.json in Resources */,

--- a/cert-walletTests/CertificateParserTests.swift
+++ b/cert-walletTests/CertificateParserTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 class CertificateParserTests: XCTestCase {
     let v1_1filename = "sample_unsigned_cert-1.1.0"
+    let v1_1signedFilename = "sample_signed_cert-valid-1.1.0"
     let v1_2filename = "sample_unsigned_cert-1.2.0"
     let v1_2signedFilename = "sample_signed_cert-1.2.0"
     
@@ -19,6 +20,18 @@ class CertificateParserTests: XCTestCase {
         guard let fileUrl = testBundle.url(forResource: v1_1filename, withExtension: "json") ,
             let file = try? Data(contentsOf: fileUrl) else {
             return
+        }
+        
+        let certificate = CertificateParser.parse(data: file)
+        XCTAssertNotNil(certificate)
+        XCTAssertEqual(certificate?.version, .oneDotOne)
+    }
+    
+    func testExpectingV1_1SignedCertificate() {
+        let testBundle = Bundle(for: type(of: self))
+        guard let fileUrl = testBundle.url(forResource: v1_1signedFilename, withExtension: "json") ,
+            let file = try? Data(contentsOf: fileUrl) else {
+                return
         }
         
         let certificate = CertificateParser.parse(data: file)

--- a/cert-walletTests/CertificateValidationRequestTests.swift
+++ b/cert-walletTests/CertificateValidationRequestTests.swift
@@ -9,11 +9,10 @@
 import XCTest
 
 class CertificateValidationRequestTests: XCTestCase {
-    let v1_1filename = "sample_signed_cert-1.1.0"
-    let v1_1transactionId = "d5df311055bf0fe656b9d6fa19aad15c915b47303e06677b812773c37050e35d"
     
-    // This is using the new CertificateValidationRequest class.
     func testTamperedV1_1Certificate() {
+        let v1_1filename = "sample_signed_cert-1.1.0"
+        let v1_1transactionId = "d5df311055bf0fe656b9d6fa19aad15c915b47303e06677b812773c37050e35d"
         let testExpectation = expectation(description: "Validation will call the completion handler")
         
         let testBundle = Bundle(for: type(of: self))
@@ -36,5 +35,27 @@ class CertificateValidationRequestTests: XCTestCase {
         request.start()
         
         waitForExpectations(timeout: 20.0, handler: nil)
-    }    
+    }
+    func testValidV1_1Certificate() {
+        let v1_1filename = "sample_signed_cert-valid-1.1.0"
+        let v1_1transactionId = "1703d2f5d706d495c1c65b40a086991ab755cc0a02bef51cd4aff9ed7a8586aa"
+        let testExpectation = expectation(description: "Validation will call the completion handler")
+        
+        let testBundle = Bundle(for: type(of: self))
+        guard let fileUrl = testBundle.url(forResource: v1_1filename, withExtension: "json") ,
+            let file = try? Data(contentsOf: fileUrl) else {
+                return
+        }
+        
+        let certificate = CertificateParser.parse(data: file)
+        XCTAssertNotNil(certificate)
+        let request = CertificateValidationRequest(for: certificate!, with:v1_1transactionId, chain: "testnet") { (success, errorMessage) in
+            XCTAssertTrue(success)
+            XCTAssertNil(errorMessage)
+            testExpectation.fulfill()
+        }
+        request.start()
+        
+        waitForExpectations(timeout: 1020.0, handler: nil)
+    }
 }


### PR DESCRIPTION
This is a valid transaction on the testnet chain that fully validates.

I added some more hacks around testnet | mainnet. We can figure out what we want here.

I fixed a few more weirdnesses caused by lack of consistent validation (formerly) in v1.1. hashed and display inputs were sometimes string, sometimes bool. I modified to handle both.
