### PR TITLE
fix issuer id names

### DIFF
--- a/Models/Issuer.swift
+++ b/Models/Issuer.swift
@@ -139,8 +139,8 @@ struct Issuer {
             self.introductionURL = nil
         }
         
-        guard let issuerKeyData = dictionary["issuer_key"] as? [[String: String]],
-            let revocationKeyData = dictionary["revocation_key"] as? [[String : String]] else {
+        guard let issuerKeyData = dictionary["issuerKeys"] as? [[String: String]],
+            let revocationKeyData = dictionary["revocationKeys"] as? [[String : String]] else {
                 return nil
         }
         
@@ -198,8 +198,8 @@ struct Issuer {
             "image": "data:image/png;base64,\(image.base64EncodedString())",
             "id": "\(id)",
             "url": "\(url)",
-            "issuer_key": serializedIssuerKeys,
-            "revocation_key": serializedRevocationKeys
+            "issuerKeys": serializedIssuerKeys,
+            "revocationKeys": serializedRevocationKeys
         ]
         if let introductionURL = introductionURL {
             dictionary["introductionURL"] = "\(introductionURL)"

--- a/Models/Requests/CertificateValidationRequest.swift
+++ b/Models/Requests/CertificateValidationRequest.swift
@@ -212,9 +212,9 @@ class CertificateValidationRequest : CommonRequest {
                 self?.state = .failure(reason: "Certificate didn't return valid JSON data from \(url)")
                 return
             }
-            guard let issuerKeys = json["issuer_key"] as? [[String : String]],
-                let revokationKeys = json["revocation_key"] as? [[String : String]] else {
-                    self?.state = .failure(reason: "Couldn't parse issuer_key or revokation_key from json: \n\(json)")
+            guard let issuerKeys = json["issuerKeys"] as? [[String : String]],
+                let revokationKeys = json["revocationKeys"] as? [[String : String]] else {
+                    self?.state = .failure(reason: "Couldn't parse issuerKeys or revokationKeys from json: \n\(json)")
                     return
             }
             guard let issuerKey = issuerKeys.first?["key"],

--- a/cert-walletTests/CertificateValidationRequestTests.swift
+++ b/cert-walletTests/CertificateValidationRequestTests.swift
@@ -75,7 +75,7 @@ class CertificateValidationRequestTests: XCTestCase {
         
         let issuerURL = URL(string: "http://www.blockcerts.org/mockissuer/issuer/got-issuer.json")!
         mockedSession.respond(to: issuerURL,
-                              with: "{\"issuer_key\":[{\"date\":\"2016-08-28\",\"key\":\"mmShyF6mhf6LeQzPdEsmiCghhgMuEn9TNF\"}],\"revocation_key\":[{\"date\":\"2016-08-28\",\"key\":\"mz7poFND7hVGRtPWjiZizcCnjf6wEDWjjT\"}]}".data(using: .utf8),
+                              with: "{\"issuerKeys\":[{\"date\":\"2016-08-28\",\"key\":\"mmShyF6mhf6LeQzPdEsmiCghhgMuEn9TNF\"}],\"revocationKeys\":[{\"date\":\"2016-08-28\",\"key\":\"mz7poFND7hVGRtPWjiZizcCnjf6wEDWjjT\"}]}".data(using: .utf8),
                               response: HTTPURLResponse(url: issuerURL, statusCode: 200, httpVersion: nil, headerFields:nil)!,
                               error: nil)
         
@@ -112,7 +112,7 @@ class CertificateValidationRequestTests: XCTestCase {
         
         let issuerURL = URL(string: "http://www.blockcerts.org/mockissuer/issuer/got-issuer.json")!
         mockedSession.respond(to: issuerURL,
-                              with: "{\"issuer_key\":[{\"date\":\"2016-08-28\",\"key\":\"mmShyF6mhf6LeQzPdEsmiCghhgMuEn9TNF\"}],\"revocation_key\":[{\"date\":\"2016-08-28\",\"key\":\"mz7poFND7hVGRtPWjiZizcCnjf6wEDWjjT\"}]}".data(using: .utf8),
+                              with: "{\"issuerKeys\":[{\"date\":\"2016-08-28\",\"key\":\"mmShyF6mhf6LeQzPdEsmiCghhgMuEn9TNF\"}],\"revocationKeys\":[{\"date\":\"2016-08-28\",\"key\":\"mz7poFND7hVGRtPWjiZizcCnjf6wEDWjjT\"}]}".data(using: .utf8),
                               response: HTTPURLResponse(url: issuerURL, statusCode: 200, httpVersion: nil, headerFields:nil)!,
                               error: nil)
         

--- a/cert-walletTests/IssuerCreationRequestTests.swift
+++ b/cert-walletTests/IssuerCreationRequestTests.swift
@@ -30,13 +30,13 @@ class IssuerCreationRequestTests: XCTestCase {
             "name": expectedName,
             "email": expectedEmail,
             "image": expectedImageData,
-            "issuer_key": [
+            "issuerKeys": [
                 [
                     "date": "2016-05-01",
                     "key": "FAKE_ISSUER_KEY"
                 ]
             ],
-            "revocation_key": [
+            "revocationKeys": [
                 [
                     "date": "2016-05-01",
                     "key": "FAKE_REVOCATION_KEY"

--- a/cert-walletTests/IssuerTests.swift
+++ b/cert-walletTests/IssuerTests.swift
@@ -56,11 +56,11 @@ class IssuerTests: XCTestCase {
         XCTAssertEqual(result["url"] as! String, urlValue)
         XCTAssertEqual(result["introductionURL"] as! String, introductionURLValue)
         
-        let issuerKeys = result["issuer_key"] as! [[String: String]]
+        let issuerKeys = result["issuerKeys"] as! [[String: String]]
         XCTAssertEqual(issuerKeys.count, 1)
         XCTAssertEqual(issuerKeys.first!, expectedIssuerKeys.first!)
         
-        let revocationKeys = result["revocation_key"] as! [[String: String]]
+        let revocationKeys = result["revocationKeys"] as! [[String: String]]
         XCTAssertEqual(revocationKeys.count, 1)
         XCTAssertEqual(revocationKeys.first!, expectedRevocationKeys.first!)
     }
@@ -74,13 +74,13 @@ class IssuerTests: XCTestCase {
             "url": urlValue,
             "publicKey": publicKeyValue,
             "introductionURL": introductionURLValue,
-            "issuer_key": [
+            "issuerKeys": [
                 [
                     "date": dateFormatter.string(from: issuerKey.on),
                     "key": issuerKey.key
                 ]
             ],
-            "revocation_key": [
+            "revocationKeys": [
                 [
                     "date": dateFormatter.string(from: revocationKey.on),
                     "key": revocationKey.key


### PR DESCRIPTION
On review of cert-viewer, it turns out that there are no external dependencies of the formerly-named issuer_key and revocation_key. So I'm changing this everywhere to xKeys for naming consistency. Pluralized while I was at it since this has always been an array

All other projects are updated. Confirmed tests pass
