### PR TITLE
Parse out the public address prefix on our example v2 certificate.

### DIFF
--- a/Frameworks/BlockchainCertificates/Requests/CertificateValidationRequest.swift
+++ b/Frameworks/BlockchainCertificates/Requests/CertificateValidationRequest.swift
@@ -146,8 +146,11 @@ public class CertificateValidationRequest : CommonRequest {
             return
         }
         
-        let targetAddress = certificate.recipient.publicAddress
-        
+        var targetAddress = certificate.recipient.publicAddress
+        let addressPrefixSeparator = ":"
+        if let separatorRange = targetAddress.range(of: addressPrefixSeparator) {
+            targetAddress = targetAddress.substring(from: separatorRange.upperBound)
+        }
         // All mainnet addresses start with 1.
         guard targetAddress.hasPrefix("1") else {
             if targetAddress.hasPrefix("m") {

--- a/Frameworks/BlockchainCertificates/Requests/CertificateValidationRequest.swift
+++ b/Frameworks/BlockchainCertificates/Requests/CertificateValidationRequest.swift
@@ -151,9 +151,10 @@ public class CertificateValidationRequest : CommonRequest {
         if let separatorRange = targetAddress.range(of: addressPrefixSeparator) {
             targetAddress = targetAddress.substring(from: separatorRange.upperBound)
         }
+        
         // All mainnet addresses start with 1.
         guard targetAddress.hasPrefix("1") else {
-            if targetAddress.hasPrefix("m") {
+            if targetAddress.hasPrefix("m") || targetAddress.hasPrefix("n") {
                 state = .failure(reason: "This is a testnet certificate. It cannot be validated.")
             } else {
                 state = .failure(reason: "This certificate is from an unknown blockchain and cannot be validated.")


### PR DESCRIPTION
Our experimental v2 certificate was failing validation because it didn't look like it was issued to main net. Turns out, our `targetAddress.hasPrefix("1")` test may be too simplistic for v2 certificates. This is a (presumably valid?) address that's in that certificate: `ecdsa-koblitz-pubkey:1AAGG6jirbu9XwikFpkHokbbiYpjVtFe1G`

I look for `:` and consider the "target address" the string after that. If that's the right thing to do, feel free to merge this. If not, then let me know what the right way is to detect mainnet on these addresses.

Thanks!