### PR TITLE
Test chain via issuer address when present

### DIFF
--- a/Frameworks/Blockcerts/CertificateV1_1.swift
+++ b/Frameworks/Blockcerts/CertificateV1_1.swift
@@ -177,6 +177,6 @@ enum MethodsForV1_1 {
             signerURL = URL(string: signer)
         }
         
-        return Verify(signer: signerURL, signedAttribute: signedAttribute, type: type)
+        return Verify(signer: signerURL, publicKey: nil, signedAttribute: signedAttribute, type: type)
     }
 }

--- a/Frameworks/Blockcerts/CertificateV2.swift
+++ b/Frameworks/Blockcerts/CertificateV2.swift
@@ -211,18 +211,16 @@ fileprivate enum MethodsForV2 {
                          metadata: Metadata(json: metadataJson),
                          htmlDisplay: htmlDisplay)
     }
+    
     static func parse(verifyJSON: AnyObject?) -> Verify? {
         guard let verifyData = verifyJSON as? [String : AnyObject],
             let type : Array<String> = verifyData["type"] as! Array<String>? else {
                 return nil
         }
         
-        var signerURL : URL? = nil
-        if let signer = verifyData["publicKey"] {
-            signerURL = URL(string: signer as! String)
-        }
-        
-        return Verify(signer: signerURL, signedAttribute: nil, type: type[0])
+        let publicKey = verifyData["publicKey"] as? String
+
+        return Verify(signer: nil, publicKey: publicKey, signedAttribute: nil, type: type[0])
     }
     
     static func parse(receiptJSON: AnyObject?) -> Receipt? {

--- a/Frameworks/Blockcerts/CertificateV2Alpha.swift
+++ b/Frameworks/Blockcerts/CertificateV2Alpha.swift
@@ -211,18 +211,16 @@ fileprivate enum MethodsForV2 {
                          metadata: Metadata(json: metadataJson),
                          htmlDisplay: htmlDisplay)
     }
+    
     static func parse(verifyJSON: AnyObject?) -> Verify? {
         guard let verifyData = verifyJSON as? [String : AnyObject],
             let type : Array<String> = verifyData["type"] as! Array<String>? else {
                 return nil
         }
         
-        var signerURL : URL? = nil
-        if let signer = verifyData["creator"] {
-            signerURL = URL(string: signer as! String)
-        }
+        let publicKey = verifyData["creator"] as? String
         
-        return Verify(signer: signerURL, signedAttribute: nil, type: type[0])
+        return Verify(signer: nil, publicKey: publicKey, signedAttribute: nil, type: type[0])
     }
     
     static func parse(receiptJSON: AnyObject?) -> Receipt? {

--- a/Frameworks/Blockcerts/Requests/CertificateValidationRequest.swift
+++ b/Frameworks/Blockcerts/Requests/CertificateValidationRequest.swift
@@ -175,7 +175,11 @@ public class CertificateValidationRequest : CommonRequest {
     }
     
     private func getChainForIssuer(_ certificate: Certificate) -> BitcoinChain? {
-        return nil
+        guard let issuerAddress = certificate.verifyData.publicKey else {
+            return nil
+        }
+        
+        return chain(for: issuerAddress)
     }
     
     private func getChainForRecipient(_ certificate: Certificate) -> BitcoinChain? {

--- a/Frameworks/Blockcerts/Verify.swift
+++ b/Frameworks/Blockcerts/Verify.swift
@@ -10,8 +10,9 @@ import Foundation
 
 /// Representing any data needed to verify a certificate.
 public struct Verify {
-    /// URI where issuer's public key is presented.
+    /// URI where issuer's public key is presented, or the public key itself. One of these will be present
     public let signer : URL?
+    public let publicKey : String?
     
     /// Name of the attribute in the json that is signed by the issuer's private key. Default is `"uid"`, referring to the uid attribute.
     public let signedAttribute : String?
@@ -19,9 +20,11 @@ public struct Verify {
     /// Name of the signing method. Default is `"ECDSA(secp256k1)"`, referring to the Bitcoin method of signing messages with the issuer's private key.
     public let type : String
     
-    public init(signer: URL?, signedAttribute: String?, type: String) {
+    public init(signer: URL?, publicKey: String?, signedAttribute: String?, type: String) {
         self.signer = signer
+        self.publicKey = publicKey
         self.signedAttribute = signedAttribute
         self.type = type
     }
 }
+

--- a/Frameworks/BlockcertsTests/CertificateV1_1Tests.swift
+++ b/Frameworks/BlockcertsTests/CertificateV1_1Tests.swift
@@ -96,6 +96,7 @@ class CertificateV1_1Tests: XCTestCase {
         
         XCTAssertEqual(verifyData.type, "ECDSA(secp256k1)")
         XCTAssertEqual(verifyData.signedAttribute, "uid")
+        XCTAssertNil(verifyData.publicKey)
         XCTAssertEqual(verifyData.signer, URL(string: "https://www.theissuer.edu/keys/signing-public-key.asc"))
     }
 }

--- a/Frameworks/BlockcertsTests/CertificateV1_2Tests.swift
+++ b/Frameworks/BlockcertsTests/CertificateV1_2Tests.swift
@@ -108,6 +108,7 @@ class CertificateV1_2SignedTests: XCTestCase {
         
         XCTAssertEqual(verifyData.type, "ECDSA(secp256k1)")
         XCTAssertEqual(verifyData.signedAttribute, "uid")
+        XCTAssertNil(verifyData.publicKey)
         XCTAssertEqual(verifyData.signer, URL(string: "http://www.blockcerts.org/mockissuer/keys/got_public_key.asc"))
     }
 }

--- a/Frameworks/BlockcertsTests/CertificateV2_0Tests.swift
+++ b/Frameworks/BlockcertsTests/CertificateV2_0Tests.swift
@@ -43,4 +43,18 @@ class CertificateV2_0Tests: XCTestCase {
         XCTAssertEqual(cert.id, "urn:uuid:bbba8553-8ec1-445f-82c9-a57251dd731c")
     }
     
+    func testImportVerifyProperties() {
+        guard let file = file,
+            let cert = try? CertificateParser.parse(data: file, asVersion: .two) else {
+                XCTFail("Failed to laod the test file in CertificateTests")
+                return
+        }
+        let verifyData = cert.verifyData
+        
+        XCTAssertEqual(verifyData.type, "MerkleProofVerification2017")
+        XCTAssertNil(verifyData.signedAttribute)
+        XCTAssertEqual(verifyData.publicKey, "ecdsa-koblitz-pubkey:msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj")
+        XCTAssertNil(verifyData.signer)
+    }
+    
 }


### PR DESCRIPTION
This change is a little more complicated than I thought, mostly to retain backwards compatibility with validation back to v1.1 certificates. It also exposed that I was handling the verify data wrong in v2.0a+ certificates.

So! This PR does a few things:
* Introduces a `publicKey` property on `Verify` objects. This will be the key itself, rather than a URL to go fetch the key from
* In v2.0a and v2.0 certificates, we read `creator` and `publicKey` fields as a key, rather than as a URL. This went uncaught because technically `ecdsa-koblitz-pubkey:mtr98kany9G1XYNU74pRnfBQmaCg2FZLmc` parses as a valid URL. Who knew?
* Updated the tests to reflect that additional property and to make sure we're parsing that section correctly.
* In `CertificateValidationRequest`, we check the issuer's chain before the recipient's. This was refactored to be a bit more readable. 

