### PR TITLE
Logging

### DIFF
--- a/Frameworks/Blockcerts/Certificate.swift
+++ b/Frameworks/Blockcerts/Certificate.swift
@@ -217,6 +217,22 @@ extension Certificate {
     var htmlDisplay : String? {
         return nil
     }
+
+    public func getDebugDescription() -> String {
+        return "version: \(version) " +
+                "title: \(title) " +
+                "subtitle: \(subtitle) " +
+                "description: \(description) " +
+                "language: \(language) " +
+                "id: \(id) " +
+                "signature: \(signature) " +
+                "issuer: \(issuer) " +
+                "recipient: \(recipient) " +
+                "verifyData: \(verifyData) " +
+                "receipt: \(receipt) " +
+                "metadata: \(metadata) " +
+                "shareUrl: \(shareUrl)"
+    }
 }
 
 // These are useful parsing functions that are version-independent.

--- a/Frameworks/Blockcerts/Requests/IssuerCreationRequest.swift
+++ b/Frameworks/Blockcerts/Requests/IssuerCreationRequest.swift
@@ -64,7 +64,11 @@ public class IssuerIdentificationRequest : CommonRequest {
             }
 
             guard let issuer = IssuerParser.decode(data: data) else {
-                self?.logger.tag(self?.tag).error("HTTP_REQUEST: failure trying to get issuer out of data: \(data)")
+                if let dataString = String(data: data, encoding: String.Encoding.utf8) {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: failure trying to get issuer out of data: \(dataString)")
+                } else {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: failure trying to get issuer out of data jsonSerializationFailure. Could not decode the data with utf8!")
+                }
                 self?.report(failure: .jsonSerializationFailure(data: data))
                 return
             }

--- a/Frameworks/Blockcerts/Requests/IssuerCreationRequest.swift
+++ b/Frameworks/Blockcerts/Requests/IssuerCreationRequest.swift
@@ -25,10 +25,12 @@ public class IssuerIdentificationRequest : CommonRequest {
     
     private var session : URLSessionProtocol
     private var currentTask : URLSessionDataTaskProtocol?
+    private var logger: LoggerProtocol
     
-    public init(id: URL, session: URLSessionProtocol = URLSession.shared, callback: ((Issuer?, IssuerIdentificationRequestError?) -> Void)?) {
+    public init(id: URL, logger: LoggerProtocol, session: URLSessionProtocol = URLSession.shared, callback: ((Issuer?, IssuerIdentificationRequestError?) -> Void)?) {
         self.callback = callback
         self.session = session
+        self.logger = logger
         url = id
     }
     

--- a/Frameworks/Blockcerts/Requests/IssuerCreationRequest.swift
+++ b/Frameworks/Blockcerts/Requests/IssuerCreationRequest.swift
@@ -19,6 +19,8 @@ public enum IssuerIdentificationRequestError : Error {
 }
 
 public class IssuerIdentificationRequest : CommonRequest {
+    private let tag = String(describing: IssuerIdentificationRequest.self)
+
     public var callback : ((Issuer?, IssuerIdentificationRequestError?) -> Void)?
     public let url : URL
     
@@ -32,44 +34,62 @@ public class IssuerIdentificationRequest : CommonRequest {
         self.session = session
         self.logger = logger
         url = id
+
+        logger.tag(tag).debug("init call with id/url: \(id)")
     }
     
     public func start() {
+        logger.tag(tag).debug("HTTP_REQUEST: request to url: \(url)")
         currentTask = session.dataTask(with: url) { [weak self] (data, response, error) in
+            self?.logger.tag(self?.tag).debug("HTTP_REQUEST: response")
             guard let response = response as? HTTPURLResponse else {
+                if let e = error {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: failure unknownResponse it was nil error: \(e)")
+                } else {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: failure unknownResponse it was nil")
+                }
                 self?.report(failure: .unknownResponse)
                 return
             }
+            self?.logger.tag(self?.tag).debug("HTTP_REQUEST: status code: \(response.statusCode)")
             guard response.statusCode == 200 else {
+                self?.logger.tag(self?.tag).error("HTTP_REQUEST: status code was not 200, it was: \(response.statusCode) with response: \(response)")
                 self?.report(failure: .httpFailure(status: response.statusCode, response: response))
                 return
             }
             guard let data = data else {
+                self?.logger.tag(self?.tag).error("HTTP_REQUEST: no data in the response")
                 self?.report(failure: .missingJSONData)
                 return
             }
 
             guard let issuer = IssuerParser.decode(data: data) else {
+                self?.logger.tag(self?.tag).error("HTTP_REQUEST: failure trying to get issuer out of data: \(data)")
                 self?.report(failure: .jsonSerializationFailure(data: data))
                 return
             }
-            
+
+            self?.logger.tag(self?.tag).info("HTTP_REQUEST: SUCCESS")
             self?.reportSuccess(with: issuer)
         }
         currentTask?.resume()
+        logger.tag(tag).info("HTTP_REQUEST: request created")
     }
     
     public func abort() {
+        logger.tag(tag).info("aborting current task")
         currentTask?.cancel()
         report(failure: .aborted)
     }
     
     private func report(failure: IssuerIdentificationRequestError) {
+        logger.tag(tag).debug("reporting failure: \(failure)")
         callback?(nil, failure)
         callback = nil
     }
     
     private func reportSuccess(with issuer: Issuer) {
+        logger.tag(tag).debug("reporting success issuer: \(issuer)")
         callback?(issuer, nil)
         callback = nil
     }

--- a/Frameworks/Blockcerts/Requests/IssuerIntroductionRequest.swift
+++ b/Frameworks/Blockcerts/Requests/IssuerIntroductionRequest.swift
@@ -93,7 +93,8 @@ public class IssuerIntroductionRequest : NSObject, CommonRequest {
         // Create JSON body. Start with the provided extra data parameters if they're present.
         var dataMap = delegate.introductionData(for: issuer, from: recipient)
         dataMap["bitcoinAddress"] = recipient.publicAddress.scopedValue
-        
+        logger.tag(tag).debug("HTTP_REQUEST: data to send \(dataMap)")
+
         guard let data = try? JSONSerialization.data(withJSONObject: dataMap, options: []) else {
             logger.tag(tag).error("HTTP_REQUEST: can not serialize \(dataMap)")
             reportFailure(.cannotSerializePostData)

--- a/Frameworks/Blockcerts/Requests/IssuerIntroductionRequest.swift
+++ b/Frameworks/Blockcerts/Requests/IssuerIntroductionRequest.swift
@@ -109,7 +109,12 @@ public class IssuerIntroductionRequest : NSObject, CommonRequest {
         currentTask = session.dataTask(with: request) { [weak self] (data, response, error) in
             self?.logger.tag(self?.tag).debug("HTTP_REQUEST: response from request: \(url)")
             guard let response = response as? HTTPURLResponse else {
-                self?.logger.tag(self?.tag).error("HTTP_REQUEST: generic error from server for request: \(url)")
+                if let e = error {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: generic error from server for request: \(url) error: \(e)")
+                } else {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: generic error from server for request: \(url)")
+                }
+
                 self?.reportFailure(.genericErrorFromServer(error: error, data: data))
                 return
             }
@@ -186,7 +191,7 @@ public class IssuerIntroductionRequest : NSObject, CommonRequest {
     }
     
     func reportFailure(_ reason: IssuerIntroductionRequestError) {
-        logger.tag(tag).debug("reporting failure \(reason.localizedDescription)")
+        logger.tag(tag).debug("reporting failure \(reason)")
         callback?(reason)
         resetState()
     }

--- a/Frameworks/Blockcerts/Requests/IssuerIntroductionRequest.swift
+++ b/Frameworks/Blockcerts/Requests/IssuerIntroductionRequest.swift
@@ -52,24 +52,31 @@ private class DefaultDelegate : IssuerIntroductionRequestDelegate {
 }
 
 public class IssuerIntroductionRequest : NSObject, CommonRequest {
+    private let tag = String(describing: IssuerIntroductionRequest.self)
+
     public var callback : ((IssuerIntroductionRequestError?) -> Void)?
     public var delegate : IssuerIntroductionRequestDelegate
-    
+
     var recipient : Recipient
     var session : URLSessionProtocol
     var currentTask : URLSessionDataTaskProtocol?
     var issuer : Issuer
+    private var logger: LoggerProtocol
     
-    public init(introduce recipient: Recipient, to issuer: Issuer, session: URLSessionProtocol = URLSession.shared, callback: ((IssuerIntroductionRequestError?) -> Void)?) {
+    public init(introduce recipient: Recipient, to issuer: Issuer, loggingTo logger: LoggerProtocol, session: URLSessionProtocol = URLSession.shared, callback: ((IssuerIntroductionRequestError?) -> Void)?) {
         self.callback = callback
         self.session = session
         self.recipient = recipient
         self.issuer = issuer
+        self.logger = logger
         
         delegate = DefaultDelegate()
+        logger.tag(tag).debug("init call with recipient: \(recipient), issuer: \(issuer)")
     }
     
     public func start() {
+        logger.tag(tag).info("start")
+
         switch issuer.introductionMethod {
         case .basic(let introductionURL):
             startBasicIntroduction(at: introductionURL)
@@ -81,11 +88,14 @@ public class IssuerIntroductionRequest : NSObject, CommonRequest {
     }
     
     func startBasicIntroduction(at url: URL) {
+        logger.tag(tag).debug("HTTP_REQUEST: start_basic_introduction with url \(url)")
+
         // Create JSON body. Start with the provided extra data parameters if they're present.
         var dataMap = delegate.introductionData(for: issuer, from: recipient)
         dataMap["bitcoinAddress"] = recipient.publicAddress.scopedValue
         
         guard let data = try? JSONSerialization.data(withJSONObject: dataMap, options: []) else {
+            logger.tag(tag).error("HTTP_REQUEST: can not serialize \(dataMap)")
             reportFailure(.cannotSerializePostData)
             return
         }
@@ -94,73 +104,101 @@ public class IssuerIntroductionRequest : NSObject, CommonRequest {
         request.httpMethod = "POST"
         request.httpBody = data
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        logger.tag(tag).debug("HTTP_REQUEST: request: \(url) with httpBody: \(data), httpMethod: POST")
         
         currentTask = session.dataTask(with: request) { [weak self] (data, response, error) in
+            self?.logger.tag(self?.tag).debug("HTTP_REQUEST: response from request: \(url)")
             guard let response = response as? HTTPURLResponse else {
+                self?.logger.tag(self?.tag).error("HTTP_REQUEST: generic error from server for request: \(url)")
                 self?.reportFailure(.genericErrorFromServer(error: error, data: data))
                 return
             }
+            self?.logger.tag(self?.tag).debug("HTTP_REQUEST: status code: \(response.statusCode)")
             guard response.statusCode == 200 else {
+                self?.logger.tag(self?.tag).warning("status code was not 200")
                 var message = ""
                 if let errorData = data,
                     let errorMessage = try? JSONDecoder().decode(ErrorMessage.self, from: errorData) {
+
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: error data \(errorData)")
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: error message\(errorMessage)")
                     message = errorMessage.message
+                } else {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: error data was nil")
                 }
 
                 if message == "Invalid nonce" {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: error authenticationFailed")
                     self?.reportFailure(.authenticationFailed)
                 } else {
+                    self?.logger.tag(self?.tag).error("HTTP_REQUEST: error errorResponseFromServer")
                     self?.reportFailure(.errorResponseFromServer(response: response, data: data))
                 }
                 return
             }
-            
+
+            self?.logger.tag(self?.tag).info("HTTP_REQUEST: request: \(url) SUCCESS")
             self?.reportSuccess()
         }
         currentTask?.resume()
+        logger.tag(tag).info("HTTP_REQUEST: request created")
     }
     
     func startWebIntroduction(at url: URL) {
+        logger.tag(tag).debug("start_web_introduction with url \(url)")
         var dataMap = delegate.introductionData(for: issuer, from: recipient)
         dataMap["bitcoinAddress"] = recipient.publicAddress
 
+        logger.tag(tag).debug("start_web_introduction with data \(dataMap)")
+
         // Translate the key/values in `dataMap` into query string parameters
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            logger.tag(tag).error("error creating url component issuerMissingIntroductionURL")
             reportFailure(.issuerMissingIntroductionURL)
             return
         }
         components.queryItems = dataMap.map { (key: String, value: Any) -> URLQueryItem in
-            return URLQueryItem(name: key, value: "\(value)")
+            let urlQueryItems = URLQueryItem(name: key, value: "\(value)")
+            logger.tag(tag).debug("query items created: \(urlQueryItems)")
+            return urlQueryItems
         }
         guard let queryURL = components.url else {
+            logger.tag(tag).error("unable to serialize postData")
             reportFailure(.cannotSerializePostData)
             return
         }
-        
+        logger.tag(tag).debug("queryURL ready: \(queryURL)")
+
+        logger.tag(tag).info("presenting webview")
         // Call our delegate to present the UI
         do {
             try delegate.presentWebView(at: queryURL, with: self)
         } catch {
+            logger.tag(tag).error("error presenting webview introductionMethodNotSupported")
             reportFailure(.introductionMethodNotSupported)
         }
     }
     
     public func abort() {
+        logger.tag(tag).info("aborting current task")
         currentTask?.cancel()
         reportFailure(.aborted)
     }
     
     func reportFailure(_ reason: IssuerIntroductionRequestError) {
+        logger.tag(tag).debug("reporting failure \(reason.localizedDescription)")
         callback?(reason)
         resetState()
     }
     
     func reportSuccess() {
+        logger.tag(tag).debug("reporting success")
         callback?(nil)
         resetState()
     }
     
     private func resetState() {
+        logger.tag(tag).debug("resetting state")
         OperationQueue.main.addOperation { [weak self] in
             self?.delegate.dismissWebView()
         }
@@ -181,12 +219,16 @@ extension IssuerIntroductionRequest : WKNavigationDelegate {
             // Remove any additional query items before comparison
             webComponents.queryItems = nil
             let compareToUrl = webComponents.url
-            
+
             if compareToUrl == errorURL {
+                logger.tag(tag).error("WKNavigationDelegate url: \(compareToUrl) equals errorURL \(errorURL) webAuthenticationFailed")
+                logger.tag(tag).info("stopping loading")
                 webView.stopLoading()
                 reportFailure(.webAuthenticationFailed)
             }
         } else {
+            logger.tag(tag).error("WKNavigationDelegate")
+            logger.tag(tag).info("stopping loading")
             webView.stopLoading()
             reportFailure(.webAuthenticationFailed)
         }
@@ -198,6 +240,8 @@ extension IssuerIntroductionRequest : WKNavigationDelegate {
         }
         
         if navigationAction.request.url == successURL {
+            logger.tag(tag).info("WKNavigationDelegate success")
+            logger.tag(tag).info("stopping loading")
             webView.stopLoading()
             reportSuccess()
         }

--- a/Frameworks/Blockcerts/Utils/LoggerUtils.swift
+++ b/Frameworks/Blockcerts/Utils/LoggerUtils.swift
@@ -1,0 +1,45 @@
+//
+// Created by Javier Moreno on 2019-02-13.
+// Copyright (c) 2019 Digital Certificates Project. All rights reserved.
+//
+
+import Foundation
+
+public protocol LoggerProtocol {
+    func tag(_ tag : String?) -> LoggerProtocol
+    func info(_ message: String)
+    func debug(_ message: String)
+    func warning(_ message: String)
+    func error(_ message: String)
+}
+
+public class DefaultLogger : LoggerProtocol {
+    var tag = ""
+
+    public func tag(_ tag: String?) -> LoggerProtocol {
+        self.tag = tag ?? ""
+        return self
+    }
+
+    public func info(_ message : String) {
+        log("info", message)
+    }
+
+    public func debug(_ message : String) {
+        log("debug", message)
+    }
+
+    public func warning(_ message : String) {
+        log("warning", message)
+    }
+
+    public func error(_ message : String) {
+        log("error", message)
+    }
+
+    private func log(_ level : String, _ message : String) {
+        let date = Date()
+        print("[\(date)] \(level)/\(tag): \(message)")
+        tag = ""
+    }
+}

--- a/Frameworks/BlockcertsTests/IssuerCreationRequestTests.swift
+++ b/Frameworks/BlockcertsTests/IssuerCreationRequestTests.swift
@@ -53,7 +53,7 @@ class IssuerIdentificationRequestTests: XCTestCase {
                         error: nil)
         
         // Create the request
-        let request = IssuerIdentificationRequest(id: url, session: session) { (issuer, error) in
+        let request = IssuerIdentificationRequest(id: url, logger: DefaultLogger(), session: session) { (issuer, error) in
             XCTAssertNotNil(issuer)
             XCTAssertEqual(issuer?.version, .one)
             XCTAssertEqual(issuer!.name, expectedName)

--- a/Frameworks/BlockcertsTests/IssuerIntroductionRequestTests.swift
+++ b/Frameworks/BlockcertsTests/IssuerIntroductionRequestTests.swift
@@ -64,7 +64,7 @@ class IssuerIntroductionRequestTests: XCTestCase {
         }
         
         // Create the request
-        let request = IssuerIntroductionRequest(introduce: recipient, to: issuer, session: session) { (possibleError) in
+        let request = IssuerIntroductionRequest(introduce: recipient, to: issuer, loggingTo: DefaultLogger(), session: session) { (possibleError) in
             XCTAssertNil(possibleError)
             itShouldCallTheCallback.fulfill()
         }
@@ -147,7 +147,7 @@ class IssuerIntroductionRequestTests: XCTestCase {
         }
         
         // Create the request
-        let request = IssuerIntroductionRequest(introduce: recipient, to: issuer, session: session) { (error) in
+        let request = IssuerIntroductionRequest(introduce: recipient, to: issuer, loggingTo: DefaultLogger(), session: session) { (error) in
             XCTAssertNil(error)
             itShouldCallTheCallback.fulfill()
         }

--- a/cert-wallet.xcodeproj/project.pbxproj
+++ b/cert-wallet.xcodeproj/project.pbxproj
@@ -10,8 +10,9 @@
 		321FEEE7FC0BF7912EB1DE29 /* libPods-cert-wallet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6F4D6EF7A2EE481444F2577 /* libPods-cert-wallet.a */; };
 		3B3F8A351EB1780D00543CBA /* sample_issuer.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B3F8A341EB1780D00543CBA /* sample_issuer.json */; };
 		3B684B0D1EBA8D2A007185AE /* sample_v1_issuer.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B684B0C1EBA8D2A007185AE /* sample_v1_issuer.json */; };
-		3B8E1E531E9BF71000DC636D /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3B90A0561E999F4F00C027B7 /* got_issuer.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B90A0551E999F4F00C027B7 /* got_issuer.json */; };
+		4ED0B9AC01B7FE34E09590E1 /* LoggerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED0BD21A63DF69A10F987E4 /* LoggerUtils.swift */; };
+		4ED0BB47185B7D0FF0E60F21 /* LoggerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED0BD21A63DF69A10F987E4 /* LoggerUtils.swift */; };
 		830ABA7D1DA84E7C00185E19 /* CoreBitcoinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ABA7C1DA84E7C00185E19 /* CoreBitcoinManager.swift */; };
 		830ABA7E1DA84E7C00185E19 /* CoreBitcoinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ABA7C1DA84E7C00185E19 /* CoreBitcoinManager.swift */; };
 		83166BBB1F17DF870022CCB0 /* sample_signed_cert-1.1.0.json in Resources */ = {isa = PBXBuildFile; fileRef = 83166B9F1F17DF870022CCB0 /* sample_signed_cert-1.1.0.json */; };
@@ -145,6 +146,7 @@
 		83EE9BBE1F2FD101005009D2 /* IssuerV2Alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EE9BBB1F2FD101005009D2 /* IssuerV2Alpha.swift */; };
 		83FF84701F1827650003E1A6 /* CertificateV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FF846F1F1827650003E1A6 /* CertificateV2.swift */; };
 		AA1B0EAE1F82FD996272EA85 /* libPods-cert-walletTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2480E99759E82A39B681E528 /* libPods-cert-walletTests.a */; };
+		EA12A1C42214E41E004965DB /* LoggerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED0BD21A63DF69A10F987E4 /* LoggerUtils.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -155,6 +157,7 @@
 			isEditable = 1;
 			outputFiles = (
 			);
+			script = "# Type a script or drag a script file from your workspace to insert its path.\n";
 		};
 /* End PBXBuildRule section */
 
@@ -273,6 +276,7 @@
 		3B684B0C1EBA8D2A007185AE /* sample_v1_issuer.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = sample_v1_issuer.json; sourceTree = "<group>"; };
 		3B90A0551E999F4F00C027B7 /* got_issuer.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = got_issuer.json; sourceTree = "<group>"; };
 		4577D4DA579179516CE8C7E7 /* Pods-cert-wallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-cert-wallet.release.xcconfig"; path = "Pods/Target Support Files/Pods-cert-wallet/Pods-cert-wallet.release.xcconfig"; sourceTree = "<group>"; };
+		4ED0BD21A63DF69A10F987E4 /* LoggerUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerUtils.swift; sourceTree = "<group>"; };
 		63DAA36016F0A82280FC66C2 /* libPods-cert-walletUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-cert-walletUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		830ABA7C1DA84E7C00185E19 /* CoreBitcoinManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreBitcoinManager.swift; sourceTree = "<group>"; };
 		83166B9F1F17DF870022CCB0 /* sample_signed_cert-1.1.0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "sample_signed_cert-1.1.0.json"; sourceTree = "<group>"; };
@@ -739,6 +743,7 @@
 		837ED9461EC37A9E0095F100 /* Blockcerts */ = {
 			isa = PBXGroup;
 			children = (
+				EAB175FA2214C2190085E3F4 /* Utils */,
 				837ED9AF1EC382080095F100 /* BitcoinManager.swift */,
 				837ED9471EC37A9E0095F100 /* Assertion.swift */,
 				837ED9481EC37A9E0095F100 /* BlockchainCertificates.h */,
@@ -864,6 +869,14 @@
 				63DAA36016F0A82280FC66C2 /* libPods-cert-walletUITests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EAB175FA2214C2190085E3F4 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				4ED0BD21A63DF69A10F987E4 /* LoggerUtils.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		FB7ABE3E3FD88A725A13B911 /* Pods */ = {
@@ -1413,6 +1426,7 @@
 				83DF831B1D8B3653006CA7AF /* Globals.swift in Sources */,
 				835B62501D64DA7700C95EB8 /* CertificateDetailViewController.swift in Sources */,
 				830ABA7D1DA84E7C00185E19 /* CoreBitcoinManager.swift in Sources */,
+				4ED0BB47185B7D0FF0E60F21 /* LoggerUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1420,10 +1434,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA12A1C42214E41E004965DB /* LoggerUtils.swift in Sources */,
 				83DF831C1D8B3653006CA7AF /* Globals.swift in Sources */,
 				83DF11C91D88617B002E8921 /* Keychain.swift in Sources */,
 				836A31BE1D5933D800943801 /* KeychainTests.swift in Sources */,
-				3B8E1E531E9BF71000DC636D /* (null) in Sources */,
 				83AC79251D678D5600AEE1FA /* CertificateValidationRequestTests.swift in Sources */,
 				830ABA7E1DA84E7C00185E19 /* CoreBitcoinManager.swift in Sources */,
 				83CD9CDE1D788D1B0077D769 /* MockURLSession.swift in Sources */,
@@ -1462,6 +1476,7 @@
 				8363EB201F33C56F008F3FC1 /* PartialIssuer.swift in Sources */,
 				837ED9701EC37A9E0095F100 /* IssuerCreationRequest.swift in Sources */,
 				837ED9731EC37A9E0095F100 /* TransactionDataHandler.swift in Sources */,
+				4ED0B9AC01B7FE34E09590E1 /* LoggerUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cert-wallet/AddIssuerViewController.swift
+++ b/cert-wallet/AddIssuerViewController.swift
@@ -133,14 +133,14 @@ class AddIssuerViewController: UIViewController {
     
     // MARK: - Contacting the issuer
     func createIssuer(from issuerUrl: URL, for recipient: Recipient, callback: ((Issuer?) -> Void)?) {
-        let creationRequest = IssuerIdentificationRequest(id: issuerUrl) { [weak self] (issuer, error) in
+        let creationRequest = IssuerIdentificationRequest(id: issuerUrl, logger: DefaultLogger()) { [weak self] (issuer, error) in
             // TODO: consume the error 
             guard let issuer = issuer else {
                 DispatchQueue.main.async { callback?(nil) }
                 return
             }
 
-            let introductionRequest = IssuerIntroductionRequest(introduce: recipient, to: issuer, callback: { (error) in
+            let introductionRequest = IssuerIntroductionRequest(introduce: recipient, to: issuer, loggingTo: DefaultLogger(), callback: { (error) in
                 if error == nil {
                     DispatchQueue.main.async { callback?(issuer) }
                 } else {


### PR DESCRIPTION
# Logs
* Added a protocol for a logger that can be passed to:
    * `IssuerCreationRequest`
    * `IssuerIntroductionRequest`
* Created a string representation of certificates that doesn't include the image or html fields to reduce the size of the output
* HTTP request are now logged, somethings to be aware of:
    * If a request fails the entire response body is logged
    * If a request succeeds the new string representation without image and html fields is going to be used to reduce the logs size